### PR TITLE
fix: corrects casing on GH keyword

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-🎟️ Fixes #
+🎟️fixes #
 
 ### Dependencies
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-🎟️fixes #
+🎟️ fixes #
 
 ### Dependencies
 


### PR DESCRIPTION
### Description
Casing seems to matter for GH keywords, so any tickets now linked after this word should be auto closed.

Keywords can be seen [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

### Changes to Core Features
Issues will now be auto closed when linked after the word `fixes`